### PR TITLE
Fix html tag auto-completion bug

### DIFF
--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -383,8 +383,8 @@ void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t car
 	if (size_t(foundTextLen) > closeTagSize - 2) // buffer size is not large enough. -2 for '/' & '\0'
 		return;
 
-	char tagHead[10];
-	_pEditView->getText(tagHead, targetStart, targetStart+9);
+	char tagHead[tagMaxLen];
+	_pEditView->getText(tagHead, targetStart, targetEnd);
 
 	if (tagHead[1] == '/') // "</toto>" will be ignored
 		return;
@@ -392,12 +392,13 @@ void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t car
 	if (strncmp(tagHead, "<!--", 4) == 0) // Comments will be ignored
 		return;
 
-	if (isHTML) // for HTML: "br", "hr", "img", "link" and "meta" will be ignored
+	if (isHTML) // for HTML: "br", "hr", "img", "link", "!doctype" and "meta" will be ignored
 	{
-		char *disallowed_tags[] = { "br", "hr", "img", "link", "meta" };
-		for (int i = 0; i < 5; ++i)
+		char *disallowedTags[] = { "br", "hr", "img", "link", "meta", "!doctype" };
+		size_t disallowedTagsLen = sizeof(disallowedTags) / sizeof(char *);
+		for (size_t i = 0; i < disallowedTagsLen; ++i)
 		{
-			if (strnicmp(tagHead + 1, disallowed_tags[i], strlen(disallowed_tags[i])) == 0)
+			if (strnicmp(tagHead + 1, disallowedTags[i], strlen(disallowedTags[i])) == 0)
 				return;
 		}
 	}
@@ -534,8 +535,8 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 
 	// if there's no user defined matched pair found, continue to check notepad++'s one
 
-	const size_t closeTagLen = 256;
-	char closeTag[closeTagLen];
+	
+	char closeTag[tagMaxLen];
 	closeTag[0] = '\0';
 	switch (character)
 	{
@@ -626,7 +627,7 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 		{
 			if (matchedPairConf._doHtmlXmlTag && (_curLang == L_HTML || _curLang == L_XML))
 			{
-				getCloseTag(closeTag, closeTagLen, caretPos, _curLang == L_HTML);
+				getCloseTag(closeTag, tagMaxLen, caretPos, _curLang == L_HTML);
 				if (closeTag[0] != '\0')
 					matchedChars = closeTag;
 			}

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.h
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.h
@@ -37,6 +37,8 @@
 #include "tinyxml.h"
 #endif// TINYXML_INCLUDED
 
+const size_t tagMaxLen = 256;
+
 class ScintillaEditView;
 
 struct MatchedCharInserted {


### PR DESCRIPTION
Closes #1510
Prevent from auto-closing html tag for "br", "hr", "img", "link" and
"meta" not working under Windows 10 32 bits. This patch fix this bug.
This patch prevents also from closing <!doctype>.